### PR TITLE
WIP: sinkhorn_wmd

### DIFF
--- a/sinkhorn_wmd/sinkhorn_wmd.py
+++ b/sinkhorn_wmd/sinkhorn_wmd.py
@@ -1,135 +1,69 @@
-"""
-Workload template
-04/18/2020 Lin Cheng (lc873@cornell.edu)
-"""
+import numpy
+import scipy.sparse
+from scipy.spatial.distance import cdist
 
-import sys
-import os
-sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir))
+# Kernel parameters.
+N_DOCS = 5000
+QUERY_IDX = 100
+LAMBDA = 1
+NUM_ITERS = 16
 
-"""
-import torch
-from torch import nn
-from torch.utils.data import DataLoader
-from torchvision import transforms
-from torchvision.datasets import MNIST
-from utils import parse_model_args, train, inference, save_model
-"""
+# Data files. (Ask Adrian for these.)
+DATA_MAT = 'data/cache-mat.npz'
+DATA_VECS = 'data/cache-vecs.npy'
 
-# -------------------------------------------------------------------------
-# Multilayer Preception for MNIST
-# -------------------------------------------------------------------------
 
-"""
-class MLPModel(nn.Module):
+def sinkhorn_wmd(r, c, vecs):
+    # I=(r > 0)
+    sel = r.squeeze() > 0
 
-    def __init__(self):
-        super(MLPModel, self).__init__()
+    # r=r(I)
+    r = r[sel].reshape(-1, 1).astype(numpy.float64)
 
-        self.mnist = nn.Sequential(nn.Linear(784, 128),
-                                   nn.ReLU(),
-                                   nn.Dropout(0.2),
-                                   nn.Linear(128, 64),
-                                   nn.ReLU(),
-                                   nn.Dropout(0.2),
-                                   nn.Linear(64, 10))
+    # M=M(I,:)
+    M = cdist(vecs[sel], vecs).astype(numpy.float64)
 
-    def forward(self, x):
-        return self.mnist(x.view(-1, 28 * 28))
-"""
+    # x=ones(lenth(r), size(c,2)) / length(r)
+    a_dim = r.shape[0]
+    b_nobs = c.shape[1]
+    x = numpy.ones((a_dim, b_nobs)) / a_dim
 
-# -------------------------------------------------------------------------
-# Workload specific command line arguments
-# -------------------------------------------------------------------------
+    # K=exp(-lambda * M)
+    K = numpy.exp(- M * LAMBDA)
+    K_div_r = K / r
+    K_T = K.T
 
-"""
-def extra_arg_parser(parser):
-    parser.add_argument('--lr', default=0.01, type=int,
-                        help="learning rate")
-"""
+    # This version uses a fixed number of iterations instead of running
+    # until convergence.
+    for it in range(NUM_ITERS):
+        print('starting iteration {}'.format(it))
+
+        u = 1.0 / x
+
+        # Here's where a better implementation is possible by doing the
+        # SDDMM thing and avoiding the dense matrix/matrix multiply. We do the
+        # slow thing for now.
+        K_T_times_u = K_T @ u
+        one_over_K_T_times_u = 1 / (K_T_times_u)
+        v = c.multiply(one_over_K_T_times_u)
+
+        x = K_div_r @ v.tocsc()
+
+    out = (u * ((K * M) @ v)).sum(axis=0)
+    return out
+
 
 if __name__ == "__main__":
-    # -------------------------------------------------------------------------
-    # Parse command line arguments
-    # -------------------------------------------------------------------------
+    # Load data.
+    vecs = numpy.load(DATA_VECS)
+    mat = scipy.sparse.load_npz(DATA_MAT)
+    mat = mat[:, :N_DOCS]  # Use a subset of the data.
 
-    """
-    args = parse_model_args(extra_arg_parser)
-    """
+    # The query vector.
+    r = numpy.asarray(mat[:, QUERY_IDX].todense()).squeeze()
 
-    # -------------------------------------------------------------------------
-    # Prepare Dataset
-    # -------------------------------------------------------------------------
+    # The kernel itself.
+    scores = sinkhorn_wmd(r, mat, vecs)
 
-    """
-    train_data = MNIST('./data', train=True, download=True,
-                       transform=transforms.ToTensor())
-    test_data = MNIST('./data', train=False, download=True,
-                      transform=transforms.ToTensor())
-
-    train_loader = DataLoader(train_data, batch_size=args.batch_size,
-                              num_workers=0)
-    test_loader = DataLoader(test_data, batch_size=args.batch_size,
-                             num_workers=0)
-    """
-
-    # -------------------------------------------------------------------------
-    # Model creation and loading
-    # -------------------------------------------------------------------------
-
-    """
-    LEARNING_RATE = args.lr
-    model = MLPModel()
-
-    optimizer = torch.optim.SGD(model.parameters(), lr=LEARNING_RATE)
-    criterion = nn.CrossEntropyLoss()
-
-    # Load pretrained model if necessary
-    if args.load_model:
-        model.load_state_dict(torch.load(args.model_filename))
-
-    # Move model to HammerBlade if using HB
-    if args.hammerblade:
-        model.to(torch.device("hammerblade"))
-
-    print(model)
-
-    # Quit here if dry run
-    if args.dry:
-        exit(0)
-    """
-
-    # -------------------------------------------------------------------------
-    # Training
-    # -------------------------------------------------------------------------
-
-    """
-    if args.training:
-
-        train(model,
-              train_loader,
-              optimizer,
-              criterion,
-              args)
-    """
-
-    # -------------------------------------------------------------------------
-    # Inference
-    # -------------------------------------------------------------------------
-
-    """
-    if args.inference:
-
-        inference(model,
-                  test_loader,
-                  criterion,
-                  args)
-    """
-
-    # -------------------------------------------------------------------------
-    # Model saving
-    # -------------------------------------------------------------------------
-    """
-    if args.save_model:
-        save_model(model, args.model_filename)
-    """
+    # Dump output.
+    numpy.savetxt('scores_out.txt', scores, fmt='%.8e')

--- a/sinkhorn_wmd/sinkhorn_wmd.py
+++ b/sinkhorn_wmd/sinkhorn_wmd.py
@@ -3,6 +3,7 @@ import scipy.sparse
 from scipy.spatial.distance import cdist
 import os
 import sys
+import torch
 
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir))
 from utils import parse_model_args, train, inference, save_model  # noqa
@@ -27,7 +28,7 @@ def swmd_numpy(r, c, vecs, niters):
     # M=M(I,:)
     M = cdist(vecs[sel], vecs).astype(numpy.float64)
 
-    # x=ones(lenth(r), size(c,2)) / length(r)
+    # x=ones(length(r), size(c,2)) / length(r)
     a_dim = r.shape[0]
     b_nobs = c.shape[1]
     x = numpy.ones((a_dim, b_nobs)) / a_dim
@@ -57,11 +58,80 @@ def swmd_numpy(r, c, vecs, niters):
     return out
 
 
+def _sparse_sample(indices, tensor):
+    """Get the values of a dense `tensor` at the given `indices`
+    (specified the same way as a sparse PyTorch tensor).
+    """
+    length = indices.shape[1]
+    values = torch.Tensor(length)
+    for i in range(length):
+        coord = tuple(indices[:, i].tolist())
+        values[i] = tensor[coord]
+    return torch.sparse.FloatTensor(
+        indices,
+        values,
+        tensor.shape,
+    )
+
+
+def swmd_torch(r, c, vecs, niters):
+    # Convert arrays to PyTorch tensors.
+    r = torch.FloatTensor(r)
+    c_coo = c.tocoo()
+    c = torch.sparse.FloatTensor(
+        torch.LongTensor(numpy.vstack((c_coo.row, c_coo.col))),
+        torch.FloatTensor(c_coo.data),
+        torch.Size(c_coo.shape),
+    )
+    vecs = torch.FloatTensor(vecs)
+
+    # I=(r > 0)
+    sel = r > 0
+
+    # r=r(I)
+    r = r[sel].reshape(-1, 1)
+
+    # M=M(I,:)
+    M = torch.cdist(vecs[sel], vecs)
+
+    # x=ones(length(r), size(c,2)) / length(r)
+    a_dim = r.shape[0]
+    b_nobs = c.shape[1]
+    x = torch.ones((a_dim, b_nobs)) / a_dim
+
+    # K=exp(-lambda * M)
+    K = torch.exp(- M * LAMBDA)
+    K_div_r = K / r
+    K_T = K.T
+
+    for it in range(niters):
+        print('starting iteration {}'.format(it))
+
+        u = 1.0 / x
+
+        K_T_times_u = K_T @ u
+        one_over_K_T_times_u = 1 / (K_T_times_u)
+
+        # PyTorch doesn't support elementwise multiply between sparse
+        # and dense matrices, so we have to convert one operand to
+        # sparse first.
+        v = c * _sparse_sample(c._indices(), one_over_K_T_times_u)
+
+        # What we really want here is `K_div_r @ v`, but PyTorch does not
+        # support dense/sparse matrix multiply (only sparse/dense).
+        x = K_div_r @ v
+
+    out = (u * ((K * M) @ v)).sum(axis=0)
+    return out
+
+
 def add_args(parser):
     parser.add_argument('-n', '--niters', default=16, type=int,
                         help="number of iterations")
-    parser.add_argument('-d', '--dump', default=False, type=bool,
+    parser.add_argument('-d', '--dump', default=False, action='store_true',
                         help="dump result to a file")
+    parser.add_argument('-p', '--numpy', default=False, action='store_true',
+                        help="use NumPy version instead of PyTorch")
 
 
 if __name__ == "__main__":
@@ -71,13 +141,15 @@ if __name__ == "__main__":
     vecs = numpy.load(DATA_VECS)
     mat = scipy.sparse.load_npz(DATA_MAT)
     mat = mat[:, :N_DOCS]  # Use a subset of the data.
+    print('data loaded')
 
     # The query vector.
     r = numpy.asarray(mat[:, QUERY_IDX].todense()).squeeze()
 
     # The kernel itself.
-    scores = swmd_numpy(r, mat, vecs,
-                        niters=args.niters)
+    kernel = swmd_numpy if args.numpy else swmd_torch
+    scores = kernel(r, mat, vecs,
+                    niters=args.niters)
 
     # Dump output.
     if args.dump:

--- a/sinkhorn_wmd/sinkhorn_wmd.py
+++ b/sinkhorn_wmd/sinkhorn_wmd.py
@@ -83,6 +83,7 @@ def _dsmp(a, b):
         bx = b._values()[k]
         for i in range(a.shape[0]):
             out[i, bj] += a[i, bi] * bx
+    return out
 
 
 def swmd_torch(r, c, vecs, niters):

--- a/sinkhorn_wmd/sinkhorn_wmd.py
+++ b/sinkhorn_wmd/sinkhorn_wmd.py
@@ -74,8 +74,8 @@ def _sparse_sample(indices, tensor):
     )
 
 
-def _sdmp(a, b):
-    """Sparse/dense matrix product.
+def _dsmp(a, b):
+    """Dense/sparse matrix product.
     """
     out = torch.zeros((a.shape[0], b.shape[1]))
     for k in range(b._nnz()):
@@ -130,9 +130,9 @@ def swmd_torch(r, c, vecs, niters):
 
         # PyTorch doesn't support dense/sparse matrix multiply (only
         # sparse/dense), so I had to write my own. :'(
-        x = _sdmp(K_div_r, v)
+        x = _dsmp(K_div_r, v)
 
-    out = (u * _sdmp(K * M, v)).sum(axis=0)
+    out = (u * _dsmp(K * M, v)).sum(axis=0)
     return out
 
 

--- a/sinkhorn_wmd/sinkhorn_wmd.py
+++ b/sinkhorn_wmd/sinkhorn_wmd.py
@@ -60,6 +60,8 @@ def swmd_numpy(r, c, vecs, niters):
 def add_args(parser):
     parser.add_argument('-n', '--niters', default=16, type=int,
                         help="number of iterations")
+    parser.add_argument('-d', '--dump', default=False, type=bool,
+                        help="dump result to a file")
 
 
 if __name__ == "__main__":
@@ -78,4 +80,5 @@ if __name__ == "__main__":
                         niters=args.niters)
 
     # Dump output.
-    numpy.savetxt('scores_out.txt', scores, fmt='%.8e')
+    if args.dump:
+        numpy.savetxt('scores_out.txt', scores, fmt='%.8e')

--- a/sinkhorn_wmd/sinkhorn_wmd.py
+++ b/sinkhorn_wmd/sinkhorn_wmd.py
@@ -1,0 +1,135 @@
+"""
+Workload template
+04/18/2020 Lin Cheng (lc873@cornell.edu)
+"""
+
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir))
+
+"""
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import transforms
+from torchvision.datasets import MNIST
+from utils import parse_model_args, train, inference, save_model
+"""
+
+# -------------------------------------------------------------------------
+# Multilayer Preception for MNIST
+# -------------------------------------------------------------------------
+
+"""
+class MLPModel(nn.Module):
+
+    def __init__(self):
+        super(MLPModel, self).__init__()
+
+        self.mnist = nn.Sequential(nn.Linear(784, 128),
+                                   nn.ReLU(),
+                                   nn.Dropout(0.2),
+                                   nn.Linear(128, 64),
+                                   nn.ReLU(),
+                                   nn.Dropout(0.2),
+                                   nn.Linear(64, 10))
+
+    def forward(self, x):
+        return self.mnist(x.view(-1, 28 * 28))
+"""
+
+# -------------------------------------------------------------------------
+# Workload specific command line arguments
+# -------------------------------------------------------------------------
+
+"""
+def extra_arg_parser(parser):
+    parser.add_argument('--lr', default=0.01, type=int,
+                        help="learning rate")
+"""
+
+if __name__ == "__main__":
+    # -------------------------------------------------------------------------
+    # Parse command line arguments
+    # -------------------------------------------------------------------------
+
+    """
+    args = parse_model_args(extra_arg_parser)
+    """
+
+    # -------------------------------------------------------------------------
+    # Prepare Dataset
+    # -------------------------------------------------------------------------
+
+    """
+    train_data = MNIST('./data', train=True, download=True,
+                       transform=transforms.ToTensor())
+    test_data = MNIST('./data', train=False, download=True,
+                      transform=transforms.ToTensor())
+
+    train_loader = DataLoader(train_data, batch_size=args.batch_size,
+                              num_workers=0)
+    test_loader = DataLoader(test_data, batch_size=args.batch_size,
+                             num_workers=0)
+    """
+
+    # -------------------------------------------------------------------------
+    # Model creation and loading
+    # -------------------------------------------------------------------------
+
+    """
+    LEARNING_RATE = args.lr
+    model = MLPModel()
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=LEARNING_RATE)
+    criterion = nn.CrossEntropyLoss()
+
+    # Load pretrained model if necessary
+    if args.load_model:
+        model.load_state_dict(torch.load(args.model_filename))
+
+    # Move model to HammerBlade if using HB
+    if args.hammerblade:
+        model.to(torch.device("hammerblade"))
+
+    print(model)
+
+    # Quit here if dry run
+    if args.dry:
+        exit(0)
+    """
+
+    # -------------------------------------------------------------------------
+    # Training
+    # -------------------------------------------------------------------------
+
+    """
+    if args.training:
+
+        train(model,
+              train_loader,
+              optimizer,
+              criterion,
+              args)
+    """
+
+    # -------------------------------------------------------------------------
+    # Inference
+    # -------------------------------------------------------------------------
+
+    """
+    if args.inference:
+
+        inference(model,
+                  test_loader,
+                  criterion,
+                  args)
+    """
+
+    # -------------------------------------------------------------------------
+    # Model saving
+    # -------------------------------------------------------------------------
+    """
+    if args.save_model:
+        save_model(model, args.model_filename)
+    """

--- a/sinkhorn_wmd/sinkhorn_wmd.py
+++ b/sinkhorn_wmd/sinkhorn_wmd.py
@@ -74,6 +74,16 @@ def _sparse_sample(indices, tensor):
     )
 
 
+def _sdmp(a, b):
+    """Sparse/dense matrix product.
+    """
+    out = torch.Tensor(torch.Size((a.shape[0], b.shape[1])))
+    for i in range(out.shape[0]):
+        for j in range(out.shape[1]):
+            for k in range(a.shape[1]):
+                out[i, j] = a[i, k] * b[k, j]
+
+
 def swmd_torch(r, c, vecs, niters):
     # Convert arrays to PyTorch tensors.
     r = torch.FloatTensor(r)
@@ -117,9 +127,9 @@ def swmd_torch(r, c, vecs, niters):
         # sparse first.
         v = c * _sparse_sample(c._indices(), one_over_K_T_times_u)
 
-        # What we really want here is `K_div_r @ v`, but PyTorch does not
-        # support dense/sparse matrix multiply (only sparse/dense).
-        x = K_div_r @ v
+        # PyTorch doesn't support dense/sparse matrix multiply (only
+        # sparse/dense), so I had to write my own. :'(
+        x = _sdmp(K_div_r, v)
 
     out = (u * ((K * M) @ v)).sum(axis=0)
     return out


### PR DESCRIPTION
This is a first attempt at the sinkhorn_wmd app. It was originally written in Numpy, and I've included a Numpy reference implementation to (eventually) check correctness.

The main reason this still WIP is because the code needs two sparse features that (stock) PyTorch does not support:

- Elementwise sparse/dense matrix multiply.
- Dense/sparse matrix product (DSMP). (PyTorch supports only the opposite, i.e., sparse/dense product.)

I have implemented both of these myself in Python, but they are… slow. I'm not really sure what to do about either of these; adding brand new kernels and exposing them in the PyTorch frontend seems like a lot of thankless work.

There is also the matter of the big, obvious algorithmic win in this benchmark, which is avoiding a dense/dense matrix product using [SDDMM](http://tensor-compiler.org/docs/machine_learning/), which also requires a custom kernel. This is a huge win that is hard to ignore (like, minutes to milliseconds).

Clerical things also remaining:

- [ ] Add a CLI flag to do comparison between PyTorch and Numpy implementations for validation.
- [ ] Provide a better way to get the input data.
- [ ] Integrate with the harness stuff (i.e., behave like recsys).