### PR TITLE
sinkhorn_wmd: Compare implementations for correctness

### DIFF
--- a/sinkhorn_wmd/sinkhorn_wmd.py
+++ b/sinkhorn_wmd/sinkhorn_wmd.py
@@ -162,13 +162,22 @@ if __name__ == "__main__":
 
     # The kernel itself.
     if args.compare:
+        # Compare the output of the reference Numpy version and our PyTorch
+        # version to ensure the output matches.
         print('starting numpy')
         scores_numpy = swmd_numpy(r, mat, vecs,
                                   niters=args.niters)
         print('starting torch')
-        scores_torch = swmd_numpy(r, mat, vecs,
+        scores_torch = swmd_torch(r, mat, vecs,
                                   niters=args.niters)
         print('done')
+        print(scores_torch)
+        print(torch.FloatTensor(scores_numpy))
+        if torch.allclose(scores_torch, torch.FloatTensor(scores_numpy)):
+            print('success! :)')
+        else:
+            print('failure :(')
+            sys.exit(1)
     else:
         kernel = swmd_numpy if args.numpy else swmd_torch
         scores = kernel(r, mat, vecs,

--- a/sinkhorn_wmd/sinkhorn_wmd.py
+++ b/sinkhorn_wmd/sinkhorn_wmd.py
@@ -144,6 +144,8 @@ def add_args(parser):
                         help="dump result to a file")
     parser.add_argument('-p', '--numpy', default=False, action='store_true',
                         help="use NumPy version instead of PyTorch")
+    parser.add_argument('-c', '--compare', default=False, action='store_true',
+                        help="compare NumPy and PyTorch output")
 
 
 if __name__ == "__main__":
@@ -159,9 +161,18 @@ if __name__ == "__main__":
     r = numpy.asarray(mat[:, QUERY_IDX].todense()).squeeze()
 
     # The kernel itself.
-    kernel = swmd_numpy if args.numpy else swmd_torch
-    scores = kernel(r, mat, vecs,
-                    niters=args.niters)
+    if args.compare:
+        print('starting numpy')
+        scores_numpy = swmd_numpy(r, mat, vecs,
+                                  niters=args.niters)
+        print('starting torch')
+        scores_torch = swmd_numpy(r, mat, vecs,
+                                  niters=args.niters)
+        print('done')
+    else:
+        kernel = swmd_numpy if args.numpy else swmd_torch
+        scores = kernel(r, mat, vecs,
+                        niters=args.niters)
 
     # Dump output.
     if args.dump:

--- a/sinkhorn_wmd/sinkhorn_wmd.py
+++ b/sinkhorn_wmd/sinkhorn_wmd.py
@@ -165,20 +165,21 @@ if __name__ == "__main__":
         # Compare the output of the reference Numpy version and our PyTorch
         # version to ensure the output matches.
         print('starting numpy')
-        scores_numpy = swmd_numpy(r, mat, vecs,
-                                  niters=args.niters)
+        scores_numpy = torch.FloatTensor(
+            swmd_numpy(r, mat, vecs, niters=args.niters)
+        )
         print('starting torch')
-        scores_torch = swmd_torch(r, mat, vecs,
-                                  niters=args.niters)
+        scores_torch = swmd_torch(r, mat, vecs, niters=args.niters)
         print('done')
         print(scores_torch)
-        print(torch.FloatTensor(scores_numpy))
-        if torch.allclose(scores_torch, torch.FloatTensor(scores_numpy)):
+        print(scores_numpy)
+        if torch.allclose(scores_torch, scores_numpy, atol=0.01):
             print('success! :)')
         else:
             print('failure :(')
             sys.exit(1)
     else:
+        # Run a single version of the kernel.
         kernel = swmd_numpy if args.numpy else swmd_torch
         scores = kernel(r, mat, vecs,
                         niters=args.niters)


### PR DESCRIPTION
Adds a `-c` flag to the sinkhorn_wmd app that compares the two implementations we have (PyTorch and a reference numpy version). Thankfully, the output actually seems to be correct, even after my recent monkeying around with it!
